### PR TITLE
Skip install default true for generator tests

### DIFF
--- a/app/templates/test-creation.js
+++ b/app/templates/test-creation.js
@@ -29,7 +29,7 @@ describe('<%= generatorName %> generator', function () {
     helpers.mockPrompt(this.app, {
       'someOption': 'Y'
     });
-
+    this.app.options['skip-install'] = true;
     this.app.run({}, function () {
       helpers.assertFiles(expected);
       done();


### PR DESCRIPTION
Might be good reasons unknown to me for keeping it as is, but it got annoying really fast.
Also had to dig a bit to figure out how to stop the behaviour, so even if you don't pull this it might be a good idea to keep it as a comment or explicitly set false.
