### PR TITLE
Update indent in jshint template

### DIFF
--- a/app/templates/test-creation.js
+++ b/app/templates/test-creation.js
@@ -6,33 +6,33 @@ var helpers = require('yeoman-generator').test;
 
 
 describe('<%= generatorName %> generator', function () {
-  beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
-      if (err) {
-        return done(err);
-      }
+    beforeEach(function (done) {
+        helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+            if (err) {
+                return done(err);
+            }
 
-      this.app = helpers.createGenerator('<%= generatorName %>:app', [
-        '../../app'
-      ]);
-      done();
-    }.bind(this));
-  });
-
-  it('creates expected files', function (done) {
-    var expected = [
-      // add files you expect to exist here.
-      '.jshintrc',
-      '.editorconfig'
-    ];
-
-    helpers.mockPrompt(this.app, {
-      'someOption': true
+            this.app = helpers.createGenerator('<%= generatorName %>:app', [
+                '../../app'
+            ]);
+            done();
+        }.bind(this));
     });
-    this.app.options['skip-install'] = true;
-    this.app.run({}, function () {
-      helpers.assertFiles(expected);
-      done();
+
+    it('creates expected files', function (done) {
+        var expected = [
+            // add files you expect to exist here.
+            '.jshintrc',
+            '.editorconfig'
+        ];
+
+        helpers.mockPrompt(this.app, {
+            'someOption': true
+        });
+        this.app.options['skip-install'] = true;
+        this.app.run({}, function () {
+            helpers.assertFiles(expected);
+            done();
+        });
     });
-  });
 });

--- a/app/templates/test-load.js
+++ b/app/templates/test-load.js
@@ -1,11 +1,11 @@
 /*global describe, beforeEach, it*/
 'use strict';
 
-var assert  = require('assert');
+var assert = require('assert');
 
 describe('<%= generatorName %> generator', function () {
-  it('can be imported without blowing up', function () {
-    var app = require('../app');
-    assert(app !== undefined);
-  });
+    it('can be imported without blowing up', function () {
+        var app = require('../app');
+        assert(app !== undefined);
+    });
 });


### PR DESCRIPTION
All the files copied from the templates folder have 2 spaces of indentation, but currently the jshintrc file that is copied indicates indentation of 4 spaces causing linting errors.

<del>This changes the indentation from `4` to `2`.</del>


**Updated:** This change changes the indentation in the template files to 4 spaces to match the `jshintrc` file.
