### PR TITLE
feat(travisyml): ensure TravisCi building dir follows generator name

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -98,7 +98,7 @@ GeneratorGenerator.prototype.projectfiles = function projectfiles() {
   this.template('_package.json', 'package.json');
   this.template('editorconfig', '.editorconfig');
   this.template('jshintrc', '.jshintrc');
-  this.template('travis.yml', '.travis.yml');
+  this.template('_travis.yml', '.travis.yml');
   this.template('README.md');
   this.template('LICENSE');
 };
@@ -117,7 +117,6 @@ GeneratorGenerator.prototype.app = function app() {
 GeneratorGenerator.prototype.templates = function copyTemplates() {
   this.copy('editorconfig', 'app/templates/editorconfig');
   this.copy('jshintrc', 'app/templates/jshintrc');
-  this.copy('travis.yml', 'app/templates/travis.yml');
   this.copy('app/templates/_package.json', 'app/templates/_package.json');
   this.copy('app/templates/_bower.json', 'app/templates/_bower.json');
 };

--- a/app/templates/_travis.yml
+++ b/app/templates/_travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - '0.8'
+  - '0.10'
+before_install:
+  - currentfolder=<%= "${PWD##*/}" %>
+  - if [ "$currentfolder" != '<%= _.slugify(appname) %>' ]; then cd .. && eval "mv $currentfolder <%= _.slugify(appname) %>" && cd <%= _.slugify(appname) %>; fi
+

--- a/app/templates/travis.yml
+++ b/app/templates/travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - '0.8'
-  - '0.10'

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -26,7 +26,7 @@ describe('Generator generator', function () {
       '.gitignore',
       '.gitattributes',
       '.jshintrc',
-      '.travis.yml',
+      ['.travis.yml', /if \[ "\$currentfolder" != 'generator-temp' \]; then cd .. \&\& eval "mv \$currentfolder generator-temp" && cd generator-temp; fi/],
       'app/index.js',
       'app/templates/_package.json',
       'app/templates/_bower.json',


### PR DESCRIPTION
Mocha tests for generators only work if they are executed in a folder that has the same name as the generator. When building in Travis, the working folder has the same name as the repo, so it is not completely assured that it will be the same as generator name.

With this PR, the travis build checks the name of the folder and it isn't like the generator's name it modifies it in the `before_install` step.
