### PR TITLE
Add preferGlobal property to root & template package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -37,5 +37,6 @@
     {
       "type": "MIT"
     }
-  ]
+  ],
+  "preferGlobal": true
 }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
     {
       "type": "MIT"
     }
-  ]
+  ],
+  "preferGlobal": true
 }


### PR DESCRIPTION
From [npm docs](https://npmjs.org/doc/files/package.json.html):

"If your package is primarily a command-line application that should be installed globally, then set this value to true to provide a warning if it is installed locally. It doesn't actually prevent users from installing it locally, but it does help prevent some confusion if it doesn't work as expected."

The yeoman home page instructs generators to be installed globally, so I think it's a good default to have this warning.
