### PR TITLE
Set license url for root and generator template package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -35,7 +35,8 @@
   },
   "licenses": [
     {
-      "type": "MIT"
+      "type": "MIT",
+      "url" : "https://github.com/<%= githubUser %>/<%= _.slugify(appname) %>/blob/master/LICENSE"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "licenses": [
     {
-      "type": "MIT"
+      "type": "MIT",
+      "url" : "https://github.com/yeoman/generator-generator/blob/master/LICENSE"
     }
   ]
 }


### PR DESCRIPTION
Set a url property for the license in package.json in addition to the license type, so that it links to the actual license text. Without this, when checking out the package info at npmjs.org, the license link points to a license boilerplate text at http://opensource.org/licenses/MIT
