### PR TITLE
Hide JSHint warning for camel case (W106)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,7 +5,9 @@ var url = require('url');
 var util = require('util');
 var yeoman = require('yeoman-generator');
 
+/* jshint -W106 */
 var proxy = process.env.http_proxy || process.env.HTTP_PROXY || process.env.https_proxy || process.env.HTTPS_PROXY || null;
+/* jshint +W106 */
 var githubOptions = {
   version: '3.0.0'
 };


### PR DESCRIPTION
JSHint complains about `http_proxy` and `https_proxy`.
