### PR TITLE
Updated inherits to extend within templated index files

### DIFF
--- a/app/templates/app/index.js
+++ b/app/templates/app/index.js
@@ -5,50 +5,52 @@ var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 
 
-var <%= _.classify(generatorName) %>Generator = module.exports = function <%= _.classify(generatorName) %>Generator(args, options, config) {
-  yeoman.generators.Base.apply(this, arguments);
+var <%= _.classify(generatorName) %>Generator = yeoman.generators.Base.extend({
+  init: function () {
+    this.pkg = yeoman.file.readJSON(path.join(__dirname, '../package.json'));
 
-  this.on('end', function () {
-    this.installDependencies({ skipInstall: options['skip-install'] });
-  });
+    this.on('end', function () {
+      if (!this.options['skip-install']) {
+        this.npmInstall();
+      }
+    });
+  },
 
-  this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
-};
+  askFor: function () {
+    var done = this.async();
 
-util.inherits(<%= _.classify(generatorName) %>Generator, yeoman.generators.Base);
+    // have Yeoman greet the user
+    console.log(this.yeoman);
 
-<%= _.classify(generatorName) %>Generator.prototype.askFor = function askFor() {
-  var cb = this.async();
+    // replace it with a short and sweet description of your generator
+    console.log(chalk.magenta('You\'re using the fantastic <%= _.classify(generatorName) %> generator.'));
 
-  // have Yeoman greet the user
-  console.log(this.yeoman);
+    var prompts = [{
+      type: 'confirm',
+      name: 'someOption',
+      message: 'Would you like to enable this option?',
+      default: true
+    }];
 
-  // replace it with a short and sweet description of your generator
-  console.log(chalk.magenta('You\'re using the fantastic <%= _.classify(generatorName) %> generator.'));
+    this.prompt(prompts, function (props) {
+      this.someOption = props.someOption;
 
-  var prompts = [{
-    type: 'confirm',
-    name: 'someOption',
-    message: 'Would you like to enable this option?',
-    default: true
-  }];
+      done();
+    }.bind(this));
+  },
 
-  this.prompt(prompts, function (props) {
-    this.someOption = props.someOption;
+  app: function () {
+    this.mkdir('app');
+    this.mkdir('app/templates');
 
-    cb();
-  }.bind(this));
-};
+    this.copy('_package.json', 'package.json');
+    this.copy('_bower.json', 'bower.json');
+  },
 
-<%= _.classify(generatorName) %>Generator.prototype.app = function app() {
-  this.mkdir('app');
-  this.mkdir('app/templates');
+  projectfiles: function () {
+    this.copy('editorconfig', '.editorconfig');
+    this.copy('jshintrc', '.jshintrc');
+  }
+});
 
-  this.copy('_package.json', 'package.json');
-  this.copy('_bower.json', 'bower.json');
-};
-
-<%= _.classify(generatorName) %>Generator.prototype.projectfiles = function projectfiles() {
-  this.copy('editorconfig', '.editorconfig');
-  this.copy('jshintrc', '.jshintrc');
-};
+module.exports = <%= _.classify(generatorName) %>Generator;

--- a/subgenerator/templates/index.js
+++ b/subgenerator/templates/index.js
@@ -2,16 +2,15 @@
 var util = require('util');
 var yeoman = require('yeoman-generator');
 
-var <%= _.classify(generatorName) %>Generator = module.exports = function <%= _.classify(generatorName) %>Generator(args, options, config) {
-  // By calling `NamedBase` here, we get the argument to the subgenerator call
-  // as `this.name`.
-  yeoman.generators.NamedBase.apply(this, arguments);
 
-  console.log('You called the <%= generatorName %> subgenerator with the argument ' + this.name + '.');
-};
+var <%= _.classify(generatorName) %>Generator = yeoman.generators.NamedBase.extend({
+  init: function () {
+    console.log('You called the <%= generatorName %> subgenerator with the argument ' + this.name + '.');
+  },
 
-util.inherits(<%= _.classify(generatorName) %>Generator, yeoman.generators.NamedBase);
+  files: function () {
+    this.copy('somefile.js', 'somefile.js');
+  }
+});
 
-<%= _.classify(generatorName) %>Generator.prototype.files = function files() {
-  this.copy('somefile.js', 'somefile.js');
-};
+module.exports = <%= _.classify(generatorName) %>Generator;


### PR DESCRIPTION
I noticed the `util.inherits` code got ditched in favor for extending, but this change never made it to the templated index.js files. Not sure if that was intentional or not, so I prepared a pr!
