### PR TITLE
Authenticate using GitHub API token if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Maintainer: [Pascal Hartig](https://github.com/passy)
 - Install: `npm install -g generator-generator`
 - Run: `yo generator`
 
+If during generation you get an error like `API rate limit exceeded`, you need to log in to GitHub
+and [create a new API token](https://github.com/settings/tokens/new), then add:
+```bash
+export GITHUB_TOKEN='YOUR_NEW_TOKEN'
+```
+to your `.bashrc`, `.zshrc`, `.profile` or another file that is run on shell initialization. In new terminal shells
+you shouldn't see this error anymore.
+
 
 ## Commands
 

--- a/app/index.js
+++ b/app/index.js
@@ -25,6 +25,13 @@ if (proxy) {
 var GitHubApi = require('github');
 var github = new GitHubApi(githubOptions);
 
+if (process.env.GITHUB_TOKEN) {
+  github.authenticate({
+    type: 'oauth',
+    token: process.env.GITHUB_TOKEN
+  });
+}
+
 var extractGeneratorName = function (_, appname) {
   var slugged = _.slugify(appname);
   var match = slugged.match(/^generator-(.+)/);


### PR DESCRIPTION
Querying GitHub API anonymously has low limits which can make people
run into errors. This commit authenticates itself using a GitHub API
token if one is provided in the GITHUB_API_TOKEN environmental variable.

Fixes #56
