### PR TITLE
Fetch GitHub username and Git name/email from Generator instead of GitHub's API

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "github": "^0.2.1",
     "lodash": "^3.6.0",
     "npm-name": "^1.0.1",
     "superb": "^1.0.0",

--- a/test/app.js
+++ b/test/app.js
@@ -8,19 +8,6 @@ var mockery = require('mockery');
 describe('generator:app', function () {
   before(function () {
     mockery.enable({warnOnUnregistered: false});
-    mockery.registerMock('github', function () {
-      return {
-        user: {
-          getFrom: function (data, cb) {
-            cb(null, JSON.stringify({
-              name: 'Tyrion Lannister',
-              email: 'imp@casterlyrock.com',
-              html_url: 'https://github.com/imp'
-            }));
-          }
-        }
-      };
-    });
 
     mockery.registerMock('superb', function () {
       return 'cat\'s meow';


### PR DESCRIPTION
Instead of requesting GitHub's API just to get user's real name and email, why not get it from git config? 

https://github.com/yeoman/generator/blob/master/lib/actions/user.js#L15-L42?

By doing this we can also avoid GitHub API limit exceeds. 

Closes #24 #56 #57