### PR TITLE
Prevent NPM from not uploading sub-gen's folders

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,9 +16,6 @@
   "scripts": {
     "test": "mocha"
   },
-  "files": [
-    "app"
-  ],
   "keywords": [
     "yeoman-generator"
   ],


### PR DESCRIPTION
NPM will not upload sub-generator folders when files property is declared like this.
