### PR TITLE
Add sub-generator folder references to package.json on sub-generator creation

### DIFF
--- a/subgenerator/index.js
+++ b/subgenerator/index.js
@@ -10,6 +10,11 @@ var SubGeneratorGenerator = module.exports = yeoman.generators.NamedBase.extend(
     //   this.log.error('You have to provide a name for the subgenerator.');
     //   process.exit(1);
     // }
+    
+    var pkg = this.dest.readJSON('package.json');
+    pkg.files = pkg.files || [];
+    pkg.files.push(this.name);
+    this.dest.write('package.json', JSON.stringify(pkg, null, 2));
 
     this.generatorName = this.name;
     this.dirname = this._.dasherize(this.name);

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -2,8 +2,10 @@
 'use strict';
 
 var path = require('path');
-var helpers = require('yeoman-generator').test;
-
+var yeoman = require('yeoman-generator')
+var helpers = yeoman.test;
+var assert = yeoman.assert;
+var fs = require('fs');
 
 describe('Generator generator', function () {
   beforeEach(function (done) {
@@ -61,9 +63,14 @@ describe('Subgenerator subgenerator', function () {
         return done(err);
       }
 
+      var mockPkgData = { files: [] };
+      fs.writeFileSync('package.json', JSON.stringify(mockPkgData, null, 2));
+
       this.app = helpers.createGenerator('generator:subgenerator', [
         '../../subgenerator'
       ], ['foo']);
+      this.app.conflicter.force = true;
+
       done();
     }.bind(this));
   });
@@ -75,8 +82,11 @@ describe('Subgenerator subgenerator', function () {
     ];
 
     this.app.run({}, function () {
+      var pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      assert.equal(pkg.files[0], 'foo');
       helpers.assertFile(expected);
       done();
     });
+
   });
 });


### PR DESCRIPTION
When creating a sub-generator, yeoman wouldn't add the new folders path to the **files array** `package.json`. This caused the sub-generators not to be available to anyone installing the generator. _json-file-plus_ to not lose `package.json`'s formatting

With this PR we add the reference to the sub-generators folder on creation. Also had to add new 

Fixes #61 
