### PR TITLE
Update the version dependency for yeoman-generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "github": "^0.2.1",
     "npm-name": "^0.2.0",
     "superb": "^1.0.0",
-    "yeoman-generator": "^0.16.0",
+    "yeoman-generator": "^0.17.0",
     "yosay": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is needed when writing a generator that uses composability, as a
lot of things are missing in version 0.16.x
