### PR TITLE
Add separate prompts

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -169,6 +169,7 @@ var GeneratorGenerator = module.exports = yeoman.generators.Base.extend({
     },
 
     templates: function () {
+      this.copy('app/prompts.js', 'app/prompts.js');
       this.copy('editorconfig', 'app/templates/editorconfig');
       this.copy('jshintrc', 'app/templates/jshintrc');
       this.copy('app/templates/_package.json', 'app/templates/_package.json');

--- a/app/templates/app/index.js
+++ b/app/templates/app/index.js
@@ -2,6 +2,7 @@
 var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 var yosay = require('yosay');
+var prompts = require('./prompts.js');
 
 module.exports = yeoman.generators.Base.extend({
   initializing: function () {
@@ -16,15 +17,9 @@ module.exports = yeoman.generators.Base.extend({
       'Welcome to the <%= superb.replace('\'', '\\\'') %> ' + chalk.red('<%= _.classify(generatorName) %>') + ' generator!'
     ));
 
-    var prompts = [{
-      type: 'confirm',
-      name: 'someOption',
-      message: 'Would you like to enable this option?',
-      default: true
-    }];
-
     this.prompt(prompts, function (props) {
-      this.someOption = props.someOption;
+      this.props = props;
+      // To access props use this.props.someOption;
 
       done();
     }.bind(this));

--- a/app/templates/app/prompts.js
+++ b/app/templates/app/prompts.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var prompts = [
+  {
+    type: 'confirm',
+    name: 'someOption',
+    message: 'Would you like to enable this option?',
+    default: true
+  },
+  {
+    type:'confirm',
+    name:'confirmOption',
+    message:'You answered yes. Are you sure?',
+    when:function (answers) {
+      return answers.someOption;
+    },
+    default:true
+  }
+];
+
+function hasFeature (feature) {
+  return function (answers) {
+    return answers[feature];
+  };
+}
+
+function hasFeatureChoice (answers,choice) {
+  return (answers) ? answers.indexOf(choice) !== -1 : false;
+}
+
+module.exports = prompts;

--- a/app/templates/test-app.js
+++ b/app/templates/test-app.js
@@ -11,7 +11,8 @@ describe('<%= generatorName %>:app', function () {
       .inDir(path.join(os.tmpdir(), './temp-test'))
       .withOptions({ 'skip-install': true })
       .withPrompt({
-        someOption: true
+        someOption: true,
+        confirmOption:true
       })
       .on('end', done);
   });

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -46,6 +46,7 @@ describe('generator:app', function () {
       '.gitattributes',
       '.jshintrc',
       'app/index.js',
+      'app/prompts.js',
       'app/templates/_package.json',
       'app/templates/_bower.json',
     ];


### PR DESCRIPTION
# Separating out Prompts
## Assumptions
* Every generator requires prompts
* Other prompts might show or be ignored if a certain choice was made 
(**when** clause from the inquirer module)

## Currently
```js
 var prompts = [{
      type: 'confirm',
      name: 'someOption',
      message: 'Would you like to enable this option?',
      default: true
    }];

    this.prompt(prompts, function (props) {
      this.someOption = props.someOption;
      this.props = props;
      // To access props use this.props.someOption;
```
### Improvement
* Instead the prompts are now in an external file `prompts.js`
* To access props use `this.props.someOption`
```js
    this.prompt(prompts, function (props) {
      this.props = props;
```
* Added logic to check if an answer exists
```js
when:function (answers) {
      return hasFeatureChoice(answers.myChoices, 'choice1');
},
```
```js
  when:hasFeature('someAnswer'),
```
```js
function hasFeature (feature) {
  return function (answers) {
    return answers[feature];
  };
}

function hasFeatureChoice (answers,choice) {
  return (answers) ? answers.indexOf(choice) !== -1 : false;
}
```