### PR TITLE
var generators = require('yeoman-generator');

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var path = require('path');
 var url = require('url');
-var yeoman = require('yeoman-generator');
+var generators = require('yeoman-generator');
 var chalk = require('chalk');
 var yosay = require('yosay');
 var npmName = require('npm-name');
@@ -64,7 +64,7 @@ var githubUserInfo = function (name, cb, log) {
   });
 };
 
-var GeneratorGenerator = module.exports = yeoman.generators.Base.extend({
+var GeneratorGenerator = module.exports = generators.Base.extend({
   initializing: function () {
     this.pkg = require('../package.json');
     this.currentYear = (new Date()).getFullYear();


### PR DESCRIPTION
Do you think this might be better for consistency with [the docs](http://yeoman.io/authoring/index.html). I was just following this tutorial and got errors because `yeoman-generator` was assigned to `yeoman` instead of `generators` like in the tutorial.