### PR TITLE
Changed namespacing of the prompt props

### DIFF
--- a/app/templates/app/index.js
+++ b/app/templates/app/index.js
@@ -24,7 +24,8 @@ module.exports = yeoman.generators.Base.extend({
     }];
 
     this.prompt(prompts, function (props) {
-      this.someOption = props.someOption;
+      this.props = props;
+      // To access props later use this.props.someOption;
 
       done();
     }.bind(this));


### PR DESCRIPTION
# Change namespacing of the prompt props
* This will reduce the amount of code needed.

## Currently
```js
    this.prompt(prompts, function (props) {
    this.someOption = props.someOption;
    this.someOtherOption = props.someOtherOption;
```
### Improvement
* To access props use `this.props.someOption`
```js
    this.prompt(prompts, function (props) {
      this.props = props;
```