### PR TITLE
:shirt: Remove unused variable declaration

### DIFF
--- a/app/templates/test-app.js
+++ b/app/templates/test-app.js
@@ -3,7 +3,6 @@
 var path = require('path');
 var assert = require('yeoman-generator').assert;
 var helpers = require('yeoman-generator').test;
-var os = require('os');
 
 describe('<%= generatorName %>:app', function () {
   before(function (done) {


### PR DESCRIPTION
Hi,
This is trivial code cleanup PR which has no side effect and makes linters happy.
The code removed was used in pre-0.18 `yeoman-generator` version to help specify directory where tests should be run. With 0.18 that is no longer required and relevant code was removed from `generator-generator`:
https://github.com/yeoman/generator-generator/commit/f2a2aab4d4fd38b959918fa8ec5cdd3103f01f2c
http://yeoman.io/blog/release-0.18.html

The declaration was not removed during 0.18 and later code upgrades, hence this PR.

Thanks!