### PR TITLE
Add --coffee flavour for scaffolding coffeescript generator files.

### DIFF
--- a/app/USAGE
+++ b/app/USAGE
@@ -11,3 +11,14 @@ Example:
         app/index.js: Main generator script
         app/templates/: Templates for files created by your generator
         test/: Unit tests for your generator
+
+    yo generator --coffee
+
+    This will create:
+        README.md: Description and minimal user instructions
+        package.json: Development packages installed by npm
+
+        app/index.js: Script to render coffeescript file
+        app/index.coffee: Main generator coffeescript
+        app/templates/: Templates for files created by your generator
+        test/: Unit tests for your generator

--- a/app/index.js
+++ b/app/index.js
@@ -77,6 +77,13 @@ module.exports = generators.Base.extend({
       defaults: false,
       desc: 'When specified, generators will be created at the top level of the project.'
     });
+
+    this.option('coffee', {
+      type: Boolean,
+      required: false,
+      defaults: false,
+      desc: 'When specified, will scaffold a coffeescript version.'
+    });
   },
 
   initializing: function () {
@@ -85,6 +92,7 @@ module.exports = generators.Base.extend({
     this.config.set('structure', this.options.flat ? 'flat' : 'nested');
     this.generatorsPrefix = this.options.flat ? '' : 'generators/';
     this.appGeneratorDir = this.options.flat ? 'app' : 'generators';
+    this.forCoffeeScript = this.options.coffee ? true : false;
   },
 
   prompting: {
@@ -182,13 +190,19 @@ module.exports = generators.Base.extend({
 
     app: function () {
       this.fs.copyTpl(
-        this.templatePath('app/index.js'),
-        this.destinationPath(this.generatorsPrefix, 'app/index.js'),
+        this.templatePath('app/index.' + (this.forCoffeeScript ? 'coffee' : 'js')),
+        this.destinationPath(this.generatorsPrefix, 'app/index.' + (this.forCoffeeScript ? 'coffee' : 'js')),
         {
           superb: superb(),
           generatorName: _s.classify(this.generatorName)
         }
       );
+      if(this.forCoffeeScript) {
+        this.fs.copyTpl(
+          this.templatePath('app/index.coffee.js'),
+          this.destinationPath(this.generatorsPrefix, 'app/index.js')
+        );
+      }
     },
 
     templates: function () {
@@ -215,13 +229,19 @@ module.exports = generators.Base.extend({
 
     tests: function () {
       this.fs.copyTpl(
-        this.templatePath('test-app.js'),
-        this.destinationPath('test/test-app.js'),
+        this.templatePath('test-app.' + (this.forCoffeeScript ? 'coffee' : 'js')),
+        this.destinationPath('test/test-app.' + (this.forCoffeeScript ? 'coffee' : 'js')),
         {
           prefix: this.generatorsPrefix,
           generatorName: this.generatorName
         }
       );
+      if(this.forCoffeeScript) {
+        this.fs.copyTpl(
+          this.templatePath('test-app.coffee.js'),
+          this.destinationPath('test/test-app.js')
+        );
+      }
     }
   },
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "yeoman-generator": "^0.19.0",
     "chalk": "^1.0.0",
-    "yosay": "^1.0.2"
+    "yosay": "^1.0.2",
+    "coffee-script": "^1.9.3"
   },
   "devDependencies": {
     "mocha": "*"

--- a/app/templates/app/index.coffee
+++ b/app/templates/app/index.coffee
@@ -1,0 +1,33 @@
+'use strict'
+yeoman = require 'yeoman-generator'
+chalk  = require 'chalk'
+yosay  = require 'yosay'
+
+class Generator extends yeoman.generators.Base
+
+    prompting : ->
+        done = @async()
+        @log yosay "Welcome to the <%= superb.replace('\'', '\\\'') %> #{chalk.red('<%= generatorName %>')} generator!"
+        prompts = [{
+            type    : 'confirm'
+            name    : 'someOption'
+            message : 'Would you like to enable this option?'
+            default : yes
+        }]
+        @prompt prompts, (props) =>
+            @props = props
+            # To access props later use @props.someOption
+
+            done()
+
+    writing:
+        app: ->
+            @fs.copy (@templatePath '_package.json'), (@destinationPath 'package.json')
+            @fs.copy (@templatePath '_bower.json'), (@destinationPath 'bower.json')
+        projectfiles: ->
+            @fs.copy (@templatePath 'editorconfig'), (@destinationPath '.editorconfig')
+            @fs.copy (@templatePath 'jshintrc'), (@destinationPath '.jshintrc')
+
+    install: -> @installDependencies()
+
+module.exports = Generator

--- a/app/templates/app/index.coffee.js
+++ b/app/templates/app/index.coffee.js
@@ -1,0 +1,2 @@
+require('coffee-script').register();
+module.exports = require('./index.coffee');

--- a/app/templates/test-app.coffee
+++ b/app/templates/test-app.coffee
@@ -1,0 +1,23 @@
+'use strict'
+path = require 'path'
+assert = (require 'yeoman-generator').assert
+helpers = (require 'yeoman-generator').test
+os = require 'os'
+
+describe '<%= generatorName %>:app', ->
+
+    before (done) ->
+        helpers.run path.join __dirname, '../<%= prefix %>app'
+        .withOptions
+            skipInstall: true
+        .withPrompts
+            someOption: true
+        .on 'end', done
+
+    it 'creates files', ->
+        assert.file [
+            'bower.json'
+            'package.json'
+            '.editorconfig'
+            '.jshintrc'
+        ]

--- a/app/templates/test-app.coffee.js
+++ b/app/templates/test-app.coffee.js
@@ -1,0 +1,3 @@
+require('coffee-script').register();
+// coffee test files
+require('./test-app.coffee');

--- a/subgenerator/USAGE
+++ b/subgenerator/USAGE
@@ -7,3 +7,10 @@ Example:
     This will create:
         your-sub-generator-name/index.js: Main sub-generator script
         your-sub-generator-name/templates/somefile.js: A file placeholder
+
+    yo generator:subgenerator <name> --coffee
+
+    This will create:
+        your-sub-generator-name/index.js: Script to render coffeescript file
+        your-sub-generator-name/index.coffee: Main sub-generator coffeescript
+        your-sub-generator-name/templates/somefile.js: A file placeholder

--- a/subgenerator/index.js
+++ b/subgenerator/index.js
@@ -11,6 +11,12 @@ module.exports = yeoman.generators.Base.extend({
       type: String,
       desc: 'The subgenerator name'
     });
+    this.option('coffee', {
+      type: Boolean,
+      required: false,
+      defaults: false,
+      desc: 'When specified, will scaffold a coffeescript version.'
+    });
   },
 
   initializing: function () {
@@ -26,6 +32,7 @@ module.exports = yeoman.generators.Base.extend({
     }
 
     this.generatorName = _s.classify(pkg.name.replace(/^generator-/, ''));
+    this.forCoffeeScript = this.options.coffee ? true : false;
   },
 
   writing: function () {
@@ -35,15 +42,27 @@ module.exports = yeoman.generators.Base.extend({
     );
 
     this.fs.copyTpl(
-      this.templatePath('index.js'),
-      this.destinationPath(this.dirname, '/index.js'),
+      this.templatePath('index.' + (this.forCoffeeScript ? 'coffee' : 'js')),
+      this.destinationPath(this.dirname, '/index.' + (this.forCoffeeScript ? 'coffee' : 'js')),
       { generatorName: this.generatorName }
     );
 
     this.fs.copyTpl(
-      this.templatePath('test-subgenerator.js'),
-      this.destinationPath('test/' + this.generatorFolder + '.js'),
+      this.templatePath('test-subgenerator.' + (this.forCoffeeScript ? 'coffee' : 'js')),
+      this.destinationPath('test/' + this.generatorFolder + (this.forCoffeeScript ? '.coffee' : '.js')),
       { generatorName: this.generatorName, dirname: this.dirname }
     );
+
+    if (this.forCoffeeScript) {
+      this.fs.copyTpl(
+        this.templatePath('index.coffee.js'),
+        this.destinationPath(this.dirname, '/index.js')
+      );
+      this.fs.copyTpl(
+        this.templatePath('test-subgenerator.coffee.js'),
+        this.destinationPath('test/' + this.generatorFolder + '.js'),
+        { generatorFolder: this.generatorFolder}
+      );
+    }
   }
 });

--- a/subgenerator/templates/index.coffee
+++ b/subgenerator/templates/index.coffee
@@ -1,0 +1,16 @@
+'use strict'
+yeoman = require 'yeoman-generator'
+
+class SubGenerator extends yeoman.generators.Base
+
+    initializing: ->
+        @argument 'name',
+            required: true
+            type: String
+            desc: 'The subgenerator name'
+        @log "You called the <%= generatorName %> subgenerator with the argument #{@name}."
+
+    writing: ->
+        @fs.copy (@templatePath 'somefile.js'), (@destinationPath 'somefile.js')
+
+module.exports = SubGenerator

--- a/subgenerator/templates/index.coffee.js
+++ b/subgenerator/templates/index.coffee.js
@@ -1,0 +1,2 @@
+require('coffee-script').register();
+module.exports = require('./index.coffee');

--- a/subgenerator/templates/test-subgenerator.coffee
+++ b/subgenerator/templates/test-subgenerator.coffee
@@ -1,0 +1,19 @@
+'use strict'
+path = require 'path'
+assert = (require 'yeoman-generator').assert
+helpers = (require 'yeoman-generator').test
+
+describe '<%= generatorName %>:<%= dirname %>', ->
+
+    before (done) ->
+        helpers.run path.join __dirname, '../<%= dirname %>'
+        .withArguments 'name'
+        .withOptions
+            skipInstall: true
+            force: true
+        .on 'end', done
+
+    it 'creates files', ->
+        assert.file [
+            'somefile.js'
+        ]

--- a/subgenerator/templates/test-subgenerator.coffee.js
+++ b/subgenerator/templates/test-subgenerator.coffee.js
@@ -1,0 +1,3 @@
+require('coffee-script').register();
+// coffee test files
+require('./<%= generatorFolder %>.coffee');

--- a/test/appCoffee.js
+++ b/test/appCoffee.js
@@ -1,0 +1,127 @@
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var assert = require('yeoman-generator').assert;
+var helpers = require('yeoman-generator').test;
+var mockery = require('mockery');
+
+describe('generator:app --coffeescript', function () {
+  before(function () {
+    mockery.enable({warnOnUnregistered: false});
+    mockery.deregisterMock('github');
+    mockery.deregisterMock('superb');
+    mockery.deregisterMock('npm-name');
+    mockery.registerMock('github', function () {
+      return {
+        user: {
+          getFrom: function (data, cb) {
+            cb(null, JSON.stringify({
+              name: 'Tyrion Lannister',
+              email: 'imp@casterlyrock.com',
+              html_url: 'https://github.com/imp'
+            }));
+          }
+        }
+      };
+    });
+
+    mockery.registerMock('superb', function () {
+      return 'cat\'s meow';
+    });
+
+    mockery.registerMock('npm-name', function (name, fn) {
+      fn(null, true);
+    });
+  });
+
+  after(function () {
+    mockery.deregisterMock('github');
+    mockery.deregisterMock('superb');
+    mockery.deregisterMock('npm-name');
+    mockery.disable();
+  });
+
+  describe('defaults', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .withOptions({
+          coffee: true
+        })
+        .withPrompts({
+          githubUser: 'imp',
+          generatorName: 'temp',
+          pkgName: false
+        })
+        .on('end', done);
+    });
+
+    it('creates files', function () {
+      var expected = [
+        '.yo-rc.json',
+        '.gitignore',
+        '.gitattributes',
+        '.jshintrc',
+        'generators/app/index.js',
+        'generators/app/index.coffee',
+        'generators/app/templates/_package.json',
+        'generators/app/templates/_bower.json',
+        'generators/app/templates/jshintrc',
+        'generators/app/templates/editorconfig'
+      ];
+
+      assert.file(expected);
+    });
+
+    it('fills package.json with correct information', function () {
+      assert.fileContent('package.json',  /"name": "generator-temp"/);
+    });
+
+    it('update package.json file array', function () {
+      var pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      assert.equal(pkg.files[0], 'generators');
+    });
+
+    it('setup travis.CI config', function () {
+      assert.fileContent(
+        '.travis.yml',
+        /node_js/
+      );
+    });
+
+    it('escapes possible apostrophes from superb in index.js', function () {
+      assert.fileContent('generators/app/index.coffee', /Welcome to the cat\\'s meow/);
+    });
+  });
+
+  describe('--flat', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../app'))
+        .withOptions({
+          coffee: true,
+          flat: true
+        })
+        .withPrompts({
+          githubUser: 'imp',
+          generatorName: 'temp',
+          pkgName: false
+        })
+        .on('end', done);
+    });
+
+    it('creates flat files structure', function () {
+      assert.file([
+        'app/index.js',
+        'app/index.coffee',
+        'app/templates/_package.json',
+        'app/templates/_bower.json',
+        'app/templates/jshintrc',
+        'app/templates/editorconfig'
+      ]);
+    });
+
+    it('update package.json file array', function () {
+      var pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+      assert.equal(pkg.files[0], 'app');
+    });
+  });
+});

--- a/test/subgeneratorCoffee.js
+++ b/test/subgeneratorCoffee.js
@@ -1,0 +1,65 @@
+'use strict';
+var path = require('path');
+var assert = require('yeoman-generator').assert;
+var helpers = require('yeoman-generator').test;
+var fs = require('fs');
+
+describe('generator:subgenerator --coffeescript', function () {
+  before(function (done) {
+    helpers.run(path.join(__dirname, '../subgenerator'))
+      .withOptions({
+        coffee: true
+      })
+      .withArguments(['foo', '--force'])
+      .inTmpDir(function (tmpDir) {
+        fs.writeFileSync(
+          path.join(tmpDir, 'package.json'),
+          '{"name": "generator-foo", "files":[]}'
+        );
+      })
+      .on('end', done);
+  });
+
+  it('creates files', function () {
+    assert.file([
+      'generators/foo/index.js',
+      'generators/foo/index.coffee',
+      'generators/foo/templates/somefile.js',
+      'test/foo.js',
+      'test/foo.coffee'
+    ]);
+  });
+});
+
+describe('generator:subgenerator --coffeescript (with flat structure)', function () {
+  before(function (done) {
+    helpers.run(path.join(__dirname, '../subgenerator'))
+      .withOptions({
+        coffee: true
+      })
+      .withArguments(['foo', '--force'])
+      .withLocalConfig({ structure: 'flat' })
+      .inTmpDir(function (tmpDir) {
+        fs.writeFileSync(
+          path.join(tmpDir, 'package.json'),
+          '{"name": "generator-foo", "files":[]}'
+        );
+      })
+      .on('end', done);
+  });
+
+  it('creates files', function () {
+    assert.file([
+      'foo/index.js',
+      'foo/index.coffee',
+      'foo/templates/somefile.js',
+      'test/foo.js',
+      'test/foo.coffee'
+    ]);
+  });
+
+  it('update package.json file array', function () {
+    var pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    assert.equal(pkg.files[0], 'foo');
+  });
+});


### PR DESCRIPTION
**Added --coffee flag for coffeescript fans.**

```shell
yo generator --coffee
```
> Will generate a coffeescript version of the main generator source file.

```shell
yo generator:subgenerator --coffee
```
> Will generate a coffeescript version of the sub generator source file.

*Relevant test cases are also included.*