### PR TITLE
update run context name

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -34,7 +34,7 @@ module.exports = generators.Base.extend({
     }.bind(this));
   },
 
-  defaults: function () {
+  default: function () {
     if (path.basename(this.destinationPath()) !== this.props.name) {
       this.log(
         'Your generator must be inside a folder named ' + this.props.name + '\n' +


### PR DESCRIPTION
According to http://yeoman.io/authoring/running-context.html, it should be `default` not `defaults` (although it would still get pushed in according to the docs)