### PR TITLE
require('yeoman-generator').generators.Base is depricated.

### DIFF
--- a/subgenerator/templates/index.js
+++ b/subgenerator/templates/index.js
@@ -3,7 +3,7 @@ var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 var yosay = require('yosay');
 
-module.exports = yeoman.generators.Base.extend({
+module.exports = yeoman.Base.extend({
   prompting: function () {
     var done = this.async();
 


### PR DESCRIPTION
  require('yeoman-generator').generators.Base is depricated.
  Use require('yeoman-generator').Base instead.

I noticed a message like this, when i was using generator-generator's generated generator. (i guess thats a 4g generator :D).