### PR TITLE
Return undefined to comply with eslint

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('test', ['pre-test'], function (cb) {
 
 gulp.task('coveralls', ['test'], function () {
   if (!process.env.CI) {
-    return;
+    return undefined;
   }
 
   return gulp.src(path.join(__dirname, 'coverage/lcov.info'))


### PR DESCRIPTION
After running the generator for the first time I'm getting an eslint error on the generated `gulpfile`:
```
57:3  error  Expected no return value  consistent-return
```
How to reproduce:

1. Create a new generator with default values
2. Run `gulp static`

Returning `undefined` explicitly makes everything green again.