### PR TITLE
Promise support - Update generator/subgenerator

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -18,9 +18,8 @@ module.exports = generators.Base.extend({
   },
 
   prompting: function () {
-    var done = this.async();
 
-    askName({
+    return askName({
       name: 'name',
       message: 'Your generator name',
       default: makeGeneratorName(path.basename(process.cwd())),
@@ -28,9 +27,8 @@ module.exports = generators.Base.extend({
       validate: function (str) {
         return str.length > 0;
       }
-    }, this, function (name) {
-      this.props.name = name;
-      done();
+    }, this).then(function (props) {
+      this.props.name = props.name;
     }.bind(this));
   },
 

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "chalk": "^1.0.0",
     "deep-extend": "^0.4.0",
     "generator-node": "^1.7.0",
-    "inquirer-npm-name": "^1.0.0",
+    "inquirer-npm-name": "^2.0.0",
     "lodash": "^4.6.1",
     "mkdirp": "^0.5.1",
     "superb": "^1.0.0",
-    "yeoman-generator": "^0.22.2",
+    "yeoman-generator": "^0.23.3",
     "yosay": "^1.0.2"
   },
   "devDependencies": {
@@ -44,7 +44,8 @@
     "mocha": "^2.2.5",
     "mockery": "^1.4.0",
     "yeoman-assert": "^2.0.0",
-    "yeoman-test": "^1.0.0"
+    "yeoman-test": "^1.0.0",
+    "pinkie-promise": "^2.0.1"
   },
   "license": "MIT"
 }

--- a/subgenerator/templates/index.js
+++ b/subgenerator/templates/index.js
@@ -6,7 +6,6 @@ var yosay = require('yosay');
 module.exports = yeoman.Base.extend({
 
   prompting: function () {
-    var done = this.async();
 
     // Have Yeoman greet the user.
     this.log(yosay(
@@ -20,19 +19,20 @@ module.exports = yeoman.Base.extend({
       default: true
     }];
 
-    this.prompt(prompts, function (props) {
-      this.props = props;
+    return this.prompt(prompts).then(function (props) {
       // To access props later use this.props.someAnswer;
+      this.props = props;
 
-      done();
     }.bind(this));
   },
 
   writing: function () {
+
     this.fs.copy(
       this.templatePath('dummyfile.txt'),
       this.destinationPath('dummyfile.txt')
     );
+    
   },
 
   install: function () {

--- a/test/app.js
+++ b/test/app.js
@@ -3,6 +3,7 @@ var path = require('path');
 var assert = require('yeoman-assert');
 var helpers = require('yeoman-test');
 var mockery = require('mockery');
+var Promise = require('pinkie-promise');
 
 describe('generator:app', function () {
   before(function () {
@@ -15,8 +16,8 @@ describe('generator:app', function () {
       return 'cat\'s meow';
     });
 
-    mockery.registerMock('npm-name', function (name, fn) {
-      fn(null, true);
+    mockery.registerMock('npm-name', function () {
+      return Promise.resolve(true);
     });
   });
 
@@ -25,8 +26,8 @@ describe('generator:app', function () {
   });
 
   describe('defaults', function () {
-    before(function (done) {
-      helpers.run(path.join(__dirname, '../app'))
+    before(function () {
+      return helpers.run(path.join(__dirname, '../app'))
         .withPrompts({
           name: 'generator-temp',
           description: 'A node generator',
@@ -38,7 +39,7 @@ describe('generator:app', function () {
           keywords: [],
           license: 'MIT'
         })
-        .on('end', done);
+        .toPromise();
     });
 
     it('created and CD into a folder named like the generator', function () {

--- a/test/subgenerator.js
+++ b/test/subgenerator.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var mockery = require('mockery');
 
 describe('generator:subgenerator', function () {
-  before(function (done) {
+  before(function () {
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false
@@ -16,7 +16,7 @@ describe('generator:subgenerator', function () {
       return 'cat\'s meow';
     });
 
-    helpers.run(path.join(__dirname, '../subgenerator'))
+    return helpers.run(path.join(__dirname, '../subgenerator'))
       .withArguments(['foo'])
       .withOptions({force: true})
       .inTmpDir(function (tmpDir) {
@@ -25,7 +25,7 @@ describe('generator:subgenerator', function () {
           '{"name": "generator-foo", "files":[]}'
         );
       })
-      .on('end', done);
+      .toPromise();
   });
 
   after(function () {


### PR DESCRIPTION
Fixes #158 

Added promise support to use the latest version of `yeoman-generator` npm package. This changes needs accept the pull request [!2](https://github.com/SBoudrias/inquirer-npm-name/pull/2) of repo [inquirer-npm-name](https://github.com/SBoudrias/inquirer-npm-name) before.

I changed to `"inquirer-npm-name": "latest"` on `package.json` file. After accept these two pull requests, please, insert the new version of this package in this key!! 