### PR TITLE
fix(prompt): Fix whitespace name bug

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -24,7 +24,7 @@ module.exports = generators.Base.extend({
       default: makeGeneratorName(path.basename(process.cwd())),
       filter: makeGeneratorName,
       validate: function (str) {
-        return str.length > 0;
+        return str.length > 'generator-'.length;
       }
     }, this).then(function (props) {
       this.props.name = props.name;


### PR DESCRIPTION
The generator by default accepts whitespace only names.
This change ensures it only accepts if a proper name is given.

----
I don't know how to write a test case for this :pensive: Please help? :worried: 