### PR TITLE
Release generator-generator 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-generator",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Generate a Yeoman generator",
   "author": "Yeoman team",
   "files": [


### PR DESCRIPTION
Is there something that prevents publishing a new major version on [npm](https://www.npmjs.com/package/generator-generator)?

Cheers, Michael