### PR TITLE
Fix test for the version of `yosay` in package.json

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -63,7 +63,7 @@ describe('generator:app', () => {
         dependencies: {
           'yeoman-generator': '^1.0.0',
           chalk: '^1.1.3',
-          yosay: '^1.2.1'
+          yosay: '^2.0.0'
         },
         devDependencies: {
           'yeoman-test': '^1.6.0',


### PR DESCRIPTION
It looks like we forgot to update the version of `yosay` that we're testing for in a generated `package.json` file after [updating to `2.0.0`](https://github.com/yeoman/generator-generator/pull/178).

Here be the fix 😄.