### PR TITLE
Add an .eslintignore file to the generated generator

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -82,6 +82,11 @@ module.exports = class extends Generator {
     pkg.keywords.push('yeoman-generator');
 
     this.fs.writeJSON(this.destinationPath('package.json'), pkg);
+
+    this.fs.copy(
+      this.templatePath('eslintignore'),
+      this.destinationPath('.eslintignore')
+    );
   }
 
   install() {

--- a/app/templates/eslintignore
+++ b/app/templates/eslintignore
@@ -1,0 +1,2 @@
+coverage
+generators/*/templates


### PR DESCRIPTION
**Important**

This won’t have any effect on running ESlint on the generated generator as long we use `--ignore-path .gitignore` like it is defined in generator-node:
https://github.com/yeoman/generator-node/blob/master/generators/eslint/index.js#L31

**Reason:**
> Keep in mind that specifying --ignore-path means that any existing .eslintignore file will not be used

See http://eslint.org/docs/user-guide/configuring#using-an-alternate-file