### PR TITLE
Use and extend .eslintignore from generator node

### DIFF
--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -30,6 +30,7 @@ describe('generator:app', () => {
 
     it('creates files', () => {
       const expected = [
+        '.eslintignore',
         'README.md',
         'package.json',
         'generators/app/index.js',
@@ -62,6 +63,10 @@ describe('generator:app', () => {
       assert.fileContent('README.md', 'npm install -g generator-temp');
       assert.fileContent('README.md', 'yo temp');
       assert.fileContent('README.md', 'yeoman/generator-temp');
+    });
+
+    it('fills the .eslintignore with correct content', () => {
+      assert.fileContent('.eslintignore', '**/templates\n');
     });
   });
 });

--- a/app/index.js
+++ b/app/index.js
@@ -44,7 +44,6 @@ module.exports = class extends Generator {
     const readmeTpl = _.template(this.fs.read(this.templatePath('README.md')));
 
     this.composeWith(require.resolve('generator-node/generators/app'), {
-      babel: false,
       boilerplate: false,
       name: this.props.name,
       projectRoot: 'generators',

--- a/app/index.js
+++ b/app/index.js
@@ -83,6 +83,10 @@ module.exports = class extends Generator {
     this.fs.writeJSON(this.destinationPath('package.json'), pkg);
   }
 
+  conflicts() {
+    this.fs.append(this.destinationPath('.eslintignore'), '**/templates\n');
+  }
+
   install() {
     this.installDependencies({bower: false});
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "deep-extend": "^0.4.1",
-    "generator-node": "^2.0.1",
+    "generator-node": "^2.1.0",
     "inquirer-npm-name": "^2.0.0",
     "lodash": "^4.17.2",
     "mkdirp": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,9 +1250,9 @@ generator-license@^5.1.0:
     git-config "^0.0.7"
     yeoman-generator "^1.0.1"
 
-generator-node@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/generator-node/-/generator-node-2.0.1.tgz#af10b89c318051f9199645c2bdb6365eb3a8502e"
+generator-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/generator-node/-/generator-node-2.1.0.tgz#bd85aa714b32f33f38e4c40807716eca4ae2eab3"
   dependencies:
     chalk "^1.1.3"
     generator-jest "^1.2.0"
@@ -2450,10 +2450,6 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-mockery@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mockery/-/mockery-2.0.0.tgz#0569a11a1848461fdc347cf8cca2df2f3129bc03"
 
 moment@2.x.x:
   version "2.18.1"


### PR DESCRIPTION
Replaces #188 since generator-node now creates an `.eslintignore` file.

