### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,25 +26,25 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^2.1.0",
     "deep-extend": "^0.5.0",
-    "generator-node": "^2.2.0",
+    "generator-node": "^2.3.0",
     "inquirer-npm-name": "^2.0.0",
-    "lodash": "^4.17.2",
+    "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "superb": "^1.3.0",
-    "yeoman-generator": "^1.0.0",
-    "yosay": "^2.0.0"
+    "yeoman-generator": "^2.0.1",
+    "yosay": "^2.0.1"
   },
   "devDependencies": {
-    "coveralls": "^2.13.1",
-    "eslint": "^4.1.0",
+    "coveralls": "^3.0.0",
+    "eslint": "^4.8.0",
     "eslint-config-xo-space": "^0.16.0",
-    "jest": "^20.0.4",
-    "jest-cli": "^20.0.4",
-    "nsp": "^2.6.3",
-    "yeoman-assert": "^3.0.0",
-    "yeoman-test": "^1.6.0"
+    "jest": "^21.2.1",
+    "jest-cli": "^21.2.1",
+    "nsp": "^2.8.1",
+    "yeoman-assert": "^3.1.0",
+    "yeoman-test": "^1.7.0"
   },
   "eslintConfig": {
     "extends": "xo-space",


### PR DESCRIPTION
I’m unsure if this requires a major bump 🤔 

It might be a major one, because we are lifting `yeoman-generator` from `1.x` to `2.x`.

What do you think?

Closes #205 