### PR TITLE
Fix additional linting errors in generated generator

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -88,6 +88,6 @@ module.exports = class extends Generator {
   }
 
   install() {
-    this.installDependencies({bower: false});
+    this.installDependencies({ bower: false });
   }
 };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "env": {
       "jest": true,
       "node": true
+    },
+    "rules": {
+      "object-curly-spacing": ["error", "always"]
     }
   },
   "jest": {

--- a/subgenerator/templates/test.js
+++ b/subgenerator/templates/test.js
@@ -5,13 +5,12 @@ const helpers = require('yeoman-test');
 
 describe('<%- generatorName %>:<%- name %>', () => {
   beforeAll(() => {
-    return helpers.run(path.join(__dirname, '../generators/<%- name %>'))
-      .withPrompts({someAnswer: true});
+    return helpers
+      .run(path.join(__dirname, '../generators/<%- name %>'))
+      .withPrompts({ someAnswer: true });
   });
 
   it('creates files', () => {
-    assert.file([
-      'dummyfile.txt'
-    ]);
+    assert.file(['dummyfile.txt']);
   });
 });


### PR DESCRIPTION
Needed to set rule object-curly-spacing to `always` because otherwise it would conflict to the prettier setup in the generated generator.

_Sorry, these slipped through_ 🙈

Related to #216 #217 