### PR TITLE
replace nsp with 'npm audit --audit-level high'

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "test": "jest",
     "pretest": "eslint . --fix",
-    "prepublish": "nsp check"
+    "prepublish": "npm audit --audit-level high"
   },
   "engines": {
     "node": ">=4.0.0"
@@ -45,7 +45,6 @@
     "eslint-plugin-prettier": "^2.6.0",
     "jest": "^23.5.0",
     "jest-cli": "^23.5.0",
-    "nsp": "^3.2.1",
     "prettier": "^1.10.2",
     "yeoman-assert": "^3.1.0",
     "yeoman-test": "^1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2733,22 +2733,6 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nsp@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/nsp/-/nsp-2.8.1.tgz#436e3f13869e0610d3a38f59d55f9b353cc32817"
-  dependencies:
-    chalk "^1.1.1"
-    cli-table "^0.3.1"
-    cvss "^1.0.0"
-    https-proxy-agent "^1.0.0"
-    joi "^6.9.1"
-    nodesecurity-npm-utils "^5.0.0"
-    path-is-absolute "^1.0.0"
-    rc "^1.1.2"
-    semver "^5.0.3"
-    subcommand "^2.0.3"
-    wreck "^6.3.0"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"


### PR DESCRIPTION
Recently, I can't publish my npm project which build with your generator:
![image](https://user-images.githubusercontent.com/17001245/50261184-5910b600-0446-11e9-8769-48baa5890124.png)
I found that `nsp` causes this error. Besides, there is a vulnerability in `nsp`:
![image](https://user-images.githubusercontent.com/17001245/50261343-22876b00-0447-11e9-9097-94882ba84400.png)
And, `nsp` has been deprecated: https://www.npmjs.com/package/nsp
So, I spend a lot of time to find solution and find this: https://stackoverflow.com/questions/53716991/node-security-service-shutdown-getaddrinfo-enotfound-api-nodesecurity-io
