### PR TITLE
feat: build and run from Docker Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,40 @@
 * `yo generator` shows a wizard for generating a new generator
 * `yo generator:subgenerator <name>` generates a subgenerator with the name `<name>`
 
+## Using Docker
+
+Download the Dockerfile:
+
+```bash
+mkdir docker
+cd docker
+wget https://github.com/yeoman/generator-generator/raw/master/docker/Dockerfile
+```
+
+Build the Docker images:
+
+```bash
+docker build -t yeoman-generator:latest .
+```
+
+Make a folder where you want to generate the generator:
+
+```bash
+mkdir generator
+cd generator
+```
+
+Run the generator from image to generate generator:
+
+```bash
+docker run -it --rm -v $PWD:/home/yeoman/generator yeoman-generator
+```
+
+Run and attach interactive shell to the generator docker container to work from inside the running container:
+
+```bash
+docker run -it --rm -v $PWD:/home/yeoman/generator yeoman-generator /bin/bash
+```
 
 ## What do you get?
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:20.04
+RUN \
+  # configure the "yeoman" user
+  groupadd yeoman && \
+  useradd yeoman -s /bin/bash -m -g yeoman -G sudo && \
+  echo 'yeoman:yeoman' |chpasswd && \
+  mkdir /home/yeoman/generator && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  export TZ=Europe\Paris && \
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+  apt-get update && \
+  # install utilities
+  apt-get install -y \
+	  wget \
+    sudo && \
+  # install node.js
+  wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \
+  tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
+  # install yeoman
+  npm install -g yo && \
+  # cleanup
+  apt-get clean && \
+  rm -rf \
+    /home/yeoman/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# install generator
+RUN npm install -g generator-generator
+
+# expose the working directory
+USER yeoman
+ENV PATH $PATH:/usr/bin
+WORKDIR "/home/yeoman/generator"
+VOLUME ["/home/yeoman/generator"]
+CMD ["yo", "generator"]


### PR DESCRIPTION
Build and run the generator from docker image support added.

The main aim and motivation behind doing this is, because
of a no. of different generator are there,
which are compatible and works with the different version of generator
and also might be incompatible with other generator or versions of generator

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>