### PR TITLE
Update "Getting started" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Getting started
 
-- Install: `npm install -g generator-generator`
+- Install: `npm install -g yo generator-generator`
 - Run: `yo generator`
 
 


### PR DESCRIPTION
I spent an hour looking for a reason why a globally installed package isn't working 😅, to realize that I need to install `yo` as well. That's why I think this little change will be helpful. 